### PR TITLE
Optional Setting for a Always-On QR-Scanner in the main-view

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -13,5 +13,6 @@
     "testFile": "Datei Testen",
     "enterAdress": "Adresse angeben: (Beginnt mit HTTP(s)://)",
     "localVersion": "Lokale Version",
-    "onlineVersion": "Online Version"
+    "onlineVersion": "Online Version",
+    "toggleLittleWidget": "Scannen über kleines Fenster"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -13,5 +13,6 @@
     "testFile": "Test file",
     "enterAdress": "Enter Adress: (Beginning with HTTP(s)://)",
     "localVersion": "Local Version",
-    "onlineVersion": "Online Version"
+    "onlineVersion": "Online Version",
+    "toggleLittleWidget": "Scan with little Camera"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -125,9 +125,11 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future _getPrefs() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    setState(() {
-      _littleWidget = prefs.getBool("littleWidget");
-    });
+    if (prefs.containsKey("littleWidget")) {
+      setState(() {
+        _littleWidget = prefs.getBool("littleWidget");
+      });
+    }
   }
 
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,20 +97,10 @@ class _MyHomePageState extends State<MyHomePage> {
   void _showOverlay(BuildContext context) async {
       final code = await Navigator.push(
         context,
-        // Create the SelectionScreen in the next step.
+        // Create the QROverlay in the next step.
         MaterialPageRoute(builder: (context) => QROverlay())
       );
-      if (code != null) {
-        setState(() {
-          _codeAvailable = true;
-          _code = code;
-        });
-      } else {
-        setState(() {
-          _codeAvailable = false;
-          _result = "noCode";
-        });
-      }
+      callback(code);
   }
 
 
@@ -136,6 +126,20 @@ class _MyHomePageState extends State<MyHomePage> {
   void initState() {
     super.initState();
     _readJson();
+  }
+
+  void callback(String code) {
+      if (code != null) {
+        setState(() {
+          _codeAvailable = true;
+          _code = code;
+        });
+      } else {
+        setState(() {
+          _codeAvailable = false;
+          _result = "noCode";
+        });
+      }
   }
 
   void _navigateSettings() async {
@@ -167,7 +171,8 @@ class _MyHomePageState extends State<MyHomePage> {
           )
         ],
       ),
-      body: _codeAvailable ? UaWidget(
+      body: new Stack(children: <Widget>[
+          _codeAvailable ? UaWidget(
             adress: _code,
             jsonString: _jsonString
           ) : Center(
@@ -178,6 +183,12 @@ class _MyHomePageState extends State<MyHomePage> {
             ],
           ),
         ),
+        new Align(
+          alignment: Alignment.bottomRight,
+          child: LittleQrWidget(callback)//LittleOverlay()
+        )
+      ]
+      ),
       floatingActionButton: _hideButton ? FloatingActionButton(
         onPressed: () {
           _navigateSettings();

--- a/lib/widget-qr.dart
+++ b/lib/widget-qr.dart
@@ -3,14 +3,14 @@ import 'package:qr_code_scanner/qr_code_scanner.dart';
 
 
 const flash_on = "FLASH ON";
-const flash_on_i = Icon(Icons.flash_on);
+const flash_on_i = Icon(Icons.flash_on, color: Colors.white,);
 const flash_off = "FLASH OFF";
-const flash_off_i = Icon(Icons.flash_off);
+const flash_off_i = Icon(Icons.flash_off, color: Colors.white,);
 
 const cam_on = "CAM ON";
-const cam_on_i = Icon(Icons.pause);
+const cam_on_i = Icon(Icons.pause, color: Colors.white,);
 const cam_paused = "CAM PAUSED";
-const cam_paused_i = Icon(Icons.play_arrow);
+const cam_paused_i = Icon(Icons.play_arrow, color: Colors.white,);
 
 
 class LittleQrWidget extends StatefulWidget {
@@ -24,70 +24,23 @@ class LittleQrWidget extends StatefulWidget {
 
 
 class _LittleQrWidget extends State<LittleQrWidget> {
-  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
-  var camStatus = cam_paused;
-  var camStatusImage = cam_paused_i;
-  QRViewController controller;
 
+  void callback(String code) {
+    this.widget.callback(code);
+  }
 
   @override
   Widget build(BuildContext context) {
     var screenSize = MediaQuery.of(context).size;
     var width = screenSize.width;
     var height = screenSize.height;
-    controller?.pauseCamera();
     return Container(
             width: width/2,
             height: height/4,
-            child: Stack(
-              children: <Widget>[
-              QRView(
-                key: qrKey,
-                onQRViewCreated: _onQRViewCreated,
-              ),
-              Align(
-                alignment: Alignment.center,
-                child: IconButton(
-                  icon: camStatusImage,
-                  onPressed: () {
-                    if(_isCameraPaused(camStatus)){
-                      controller?.resumeCamera();
-                      setState(() {
-                        camStatus = cam_on;
-                        camStatusImage = cam_on_i;
-                      });
-                    } else {
-                      controller?.pauseCamera();
-                      setState(() {
-                        camStatus = cam_paused;
-                        camStatusImage = cam_paused_i;
-                      });
-                    }
-                  },
-                ),
-              )
-            ]
-            )
+            child: CameraView(callback)
           );
   }
-
-  void _onQRViewCreated(QRViewController controller) {
-    this.controller = controller;
-    controller.scannedDataStream.listen((scanData) {
-      this.widget.callback(scanData);
-    });
-  }
-
-  @override
-  void dispose() {
-    controller?.dispose();
-    super.dispose();
-  }
-  _isCameraPaused(String current) {
-    return cam_paused == current;
-  }
 }
-
 
 
 class QrWidget extends StatefulWidget {
@@ -99,10 +52,12 @@ class QrWidget extends StatefulWidget {
 class _QrWidget extends State<QrWidget> {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
   var qrText = "";
-  var flashState = flash_on;
-  var flashImage = flash_on_i;
-  var camStatus = cam_on;
-  var camStatusImage = cam_on_i;
+
+  void callback(String code) {
+    setState(() {
+      qrText = code;
+    });
+  }
 
   QRViewController controller;
 
@@ -115,89 +70,7 @@ class _QrWidget extends State<QrWidget> {
       // Camera (QR-Scan) Widget
       Expanded(
         flex: 5,
-        child:  QRView(
-          key: qrKey,
-          onQRViewCreated: _onQRViewCreated,
-        ),
-      ),
-      // Controls for the Camera Widget
-      Expanded(
-        flex: 1,
-        child: FittedBox(
-          fit: BoxFit.contain,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: <Widget>[
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  // ######  Flash Button
-                  Container(
-                    margin: EdgeInsets.all(8.0),
-                    child: RaisedButton(
-                      onPressed: () {
-                        if (controller != null) {
-                          controller.toggleFlash();
-                          if (_isFlashOn(flashState)) {
-                            setState(() {
-                              flashState = flash_off;
-                              flashImage = flash_off_i;
-                            });
-                          } else {
-                            setState(() {
-                              flashState = flash_on;
-                              flashImage = flash_on_i;
-                            });
-                          }
-                        }
-                      },
-                      child: flashImage
-                    ),
-                  ),
-                  // ######  Camera Flip Button
-                  Container(
-                    margin: EdgeInsets.all(8.0),
-                    child: RaisedButton(
-                      onPressed: () {
-                        if (controller != null) {
-                          controller.flipCamera();
-                          setState(() {
-                            camStatus = cam_on;
-                            camStatusImage = cam_on_i;
-                          });
-                        }
-                      },
-                      child: Icon(Icons.switch_camera)
-                    ),
-                  ),
-                  // ######  Pause Camera Button
-                  Container(
-                    margin: EdgeInsets.all(8.0),
-                    child: RaisedButton(
-                      onPressed: () {
-                        if(_isCameraPaused(camStatus)){
-                          controller?.resumeCamera();
-                          setState(() {
-                            camStatus = cam_on;
-                            camStatusImage = cam_on_i;
-                          });
-                        } else {
-                          controller?.pauseCamera();
-                          setState(() {
-                            camStatus = cam_paused;
-                            camStatusImage = cam_paused_i;
-                          });
-                        }
-                      },
-                      child: camStatusImage
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
+        child:  CameraView(callback)
       ),
       Expanded(
         flex: 1,
@@ -264,22 +137,107 @@ class _QrWidget extends State<QrWidget> {
     ],
     );
   }
+}
 
-  _isFlashOn(String current) {
-    return flash_on == current;
-  }
+// ###########################################
+// ###    Camera View with Controls        ###
+// ###########################################
+
+class CameraView extends StatefulWidget {
+  Function callback;
+
+  CameraView(this.callback);
+
+  @override
+  _CameraView createState() => _CameraView();
+}
 
 
-  _isCameraPaused(String current) {
-    return cam_paused == current;
+class _CameraView extends State<CameraView> {
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  var flashState = flash_on;
+  var flashImage = flash_on_i;
+  var camStatus = cam_on;
+  var camStatusImage = cam_on_i;
+
+  QRViewController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        QRView(
+          key: qrKey,
+          onQRViewCreated: _onQRViewCreated,
+        ),
+        Align(
+          alignment: Alignment.topCenter,
+          child: Container(
+            color: Colors.black.withOpacity(0.2),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                IconButton(
+                  icon: flashImage,
+                  onPressed: () {
+                  if (controller != null) {
+                    controller.toggleFlash();
+                    if (_isFlashOn(flashState)) {
+                      setState(() {
+                        flashState = flash_off;
+                        flashImage = flash_off_i;
+                      });
+                    } else {
+                      setState(() {
+                        flashState = flash_on;
+                        flashImage = flash_on_i;
+                      });
+                    }
+                  }
+                },
+                ),
+                IconButton(
+                  icon: camStatusImage,
+                  onPressed: () {
+                    if(_isCameraPaused(camStatus)){
+                      controller?.resumeCamera();
+                      setState(() {
+                        camStatus = cam_on;
+                        camStatusImage = cam_on_i;
+                      });
+                    } else {
+                      controller?.pauseCamera();
+                      setState(() {
+                        camStatus = cam_paused;
+                        camStatusImage = cam_paused_i;
+                      });
+                    }
+                  },
+                ),
+                IconButton(
+                  icon: Icon(Icons.switch_camera, color: Colors.white,),
+                  onPressed: () {
+                    if (controller != null) {
+                      controller.flipCamera();
+                      setState(() {
+                        camStatus = cam_on;
+                        camStatusImage = cam_on_i;
+                      });
+                    }
+                  },
+                )
+              ],
+            ) 
+          )
+        )
+      ]
+    );
   }
 
   void _onQRViewCreated(QRViewController controller) {
     this.controller = controller;
     controller.scannedDataStream.listen((scanData) {
-      setState(() {
-        qrText = scanData;
-      });
+      this.widget.callback(scanData);
     });
   }
 
@@ -287,5 +245,13 @@ class _QrWidget extends State<QrWidget> {
   void dispose() {
     controller?.dispose();
     super.dispose();
+  }
+
+  _isFlashOn(String current) {
+    return flash_on == current;
+  }
+
+  _isCameraPaused(String current) {
+    return cam_paused == current;
   }
 }

--- a/lib/widget-qr.dart
+++ b/lib/widget-qr.dart
@@ -13,6 +13,83 @@ const cam_paused = "CAM PAUSED";
 const cam_paused_i = Icon(Icons.play_arrow);
 
 
+class LittleQrWidget extends StatefulWidget {
+  Function callback;
+
+  LittleQrWidget(this.callback);
+
+  @override
+  _LittleQrWidget createState() => _LittleQrWidget();
+}
+
+
+class _LittleQrWidget extends State<LittleQrWidget> {
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  var camStatus = cam_paused;
+  var camStatusImage = cam_paused_i;
+  QRViewController controller;
+
+
+  @override
+  Widget build(BuildContext context) {
+    var screenSize = MediaQuery.of(context).size;
+    var width = screenSize.width;
+    var height = screenSize.height;
+    controller?.pauseCamera();
+    return Container(
+            width: width/2,
+            height: height/4,
+            child: Stack(
+              children: <Widget>[
+              QRView(
+                key: qrKey,
+                onQRViewCreated: _onQRViewCreated,
+              ),
+              Align(
+                alignment: Alignment.center,
+                child: IconButton(
+                  icon: camStatusImage,
+                  onPressed: () {
+                    if(_isCameraPaused(camStatus)){
+                      controller?.resumeCamera();
+                      setState(() {
+                        camStatus = cam_on;
+                        camStatusImage = cam_on_i;
+                      });
+                    } else {
+                      controller?.pauseCamera();
+                      setState(() {
+                        camStatus = cam_paused;
+                        camStatusImage = cam_paused_i;
+                      });
+                    }
+                  },
+                ),
+              )
+            ]
+            )
+          );
+  }
+
+  void _onQRViewCreated(QRViewController controller) {
+    this.controller = controller;
+    controller.scannedDataStream.listen((scanData) {
+      this.widget.callback(scanData);
+    });
+  }
+
+  @override
+  void dispose() {
+    controller?.dispose();
+    super.dispose();
+  }
+  _isCameraPaused(String current) {
+    return cam_paused == current;
+  }
+}
+
+
+
 class QrWidget extends StatefulWidget {
   @override
   _QrWidget createState() => _QrWidget();

--- a/lib/widget-settings.dart
+++ b/lib/widget-settings.dart
@@ -200,10 +200,32 @@ class _FormWidget extends State<FormWidget> {
 
 // ###################### Main Settings Widget ##########################################
 class SettingsWidget extends StatefulWidget {
+
+  
   _SettingsWidget createState() => _SettingsWidget();
 }
 
 class _SettingsWidget extends State<SettingsWidget> {
+  bool _littleWidget = false;
+
+  Future _toggleLittleWidget(value) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    prefs.setBool("littleWidget", value);
+  }
+
+  Future _getPrefs() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _littleWidget = prefs.getBool("littleWidget");
+    });
+  }
+
+@override
+  void initState() {
+    _getPrefs();
+    super.initState();
+  }
+
   @override
   Widget build (BuildContext context) {
   return Scaffold(
@@ -221,7 +243,17 @@ class _SettingsWidget extends State<SettingsWidget> {
               ],
             ),
             FormWidget(),
-          ],
+            SwitchListTile(
+                  title: Text(AppLocalizations.of(context).translate('toggleLittleWidget')),
+                  value: _littleWidget,
+                  onChanged: (bool value) {
+                    _toggleLittleWidget(value);
+                    setState(() {
+                      _littleWidget = value;
+                    });
+                  },
+                ),
+              ]
         )
       ),
     );

--- a/lib/widget-settings.dart
+++ b/lib/widget-settings.dart
@@ -215,9 +215,11 @@ class _SettingsWidget extends State<SettingsWidget> {
 
   Future _getPrefs() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    setState(() {
-      _littleWidget = prefs.getBool("littleWidget");
-    });
+    if (prefs.containsKey("littleWidget")) {
+      setState(() {
+        _littleWidget = prefs.getBool("littleWidget");
+      });
+    }
   }
 
 @override


### PR DESCRIPTION
Support a Always-On QR-Scanner to scan large amounts of codes in shorter time, i.e. while inspecting a new building.